### PR TITLE
add comment identifer for use in mono repo with multiple test projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For failed test runs you can expand each failed test and view more details about
 | `update-comment-if-one-exists` | false       | true                             | When `create-pr-comment` is true, this flag determines whether a new comment is created or if the action updates an existing comment if one is found which is the default behavior. |
 | `ignore-test-failures`         | false       | `false`                          | When set to true the check status is set to `Neutral` when there are test failures and it will not block pull requests.                                                             |
 | `timezone`                     | false       | `UTC`                            | IANA time zone name (e.g. America/Denver) to display dates in.                                                                                                                      |
-| `comment-identifier`           | false       | ``                               | Used when there is multiple test run results per run and update each comment separately
+| `comment-identifier`           | false       | ``                               | Used when there is multiple test projects that run separtely but part of the same CI run.
 
 ## Outputs
 | Output         | Description                                                                                                                                                           |
@@ -112,6 +112,7 @@ jobs:
           update-comment-if-one-exists: true            # Default: true
           ignore-test-failures: true                    # Default: false
           timezone: 'america/denver'                    # Default: UTC
+          comment-identifier: 'bff-tests'               # Default: empty string
       
       - run: ./do-other-advanced-things-in-the-build.sh
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For failed test runs you can expand each failed test and view more details about
 | `update-comment-if-one-exists` | false       | true                             | When `create-pr-comment` is true, this flag determines whether a new comment is created or if the action updates an existing comment if one is found which is the default behavior. |
 | `ignore-test-failures`         | false       | `false`                          | When set to true the check status is set to `Neutral` when there are test failures and it will not block pull requests.                                                             |
 | `timezone`                     | false       | `UTC`                            | IANA time zone name (e.g. America/Denver) to display dates in.                                                                                                                      |
-| `comment-identifier`           | false       | ``                               | Used when there is multiple test projects that run separtely but part of the same CI run.
+| `comment-identifier`           | false       | ``                               | Used when there are multiple test projects that run separately but are part of the same CI run.
 
 ## Outputs
 | Output         | Description                                                                                                                                                           |
@@ -103,7 +103,7 @@ jobs:
       
       - name: Process trx reports
         id: process-trx
-        uses: im-open/process-dotnet-test-results@v2.1.2
+        uses: im-open/process-dotnet-test-results@v2.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           base-directory: './test-results'              # Default: .

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ jobs:
 
       - name: Process trx reports with default
         if: always()
-        uses: im-open/process-dotnet-test-results@v2.0.2
+        uses: im-open/process-dotnet-test-results@v2.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ jobs:
       
       - name: Process trx reports
         id: process-trx
-        uses: im-open/process-dotnet-test-results@v2.0.2
+        uses: im-open/process-dotnet-test-results@v2.1.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           base-directory: './test-results'              # Default: .

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ For failed test runs you can expand each failed test and view more details about
 | `update-comment-if-one-exists` | false       | true                             | When `create-pr-comment` is true, this flag determines whether a new comment is created or if the action updates an existing comment if one is found which is the default behavior. |
 | `ignore-test-failures`         | false       | `false`                          | When set to true the check status is set to `Neutral` when there are test failures and it will not block pull requests.                                                             |
 | `timezone`                     | false       | `UTC`                            | IANA time zone name (e.g. America/Denver) to display dates in.                                                                                                                      |
+| `comment-identifier`           | false       | ``                               | Used when there is multiple test run results per run and update each comment separately
 
 ## Outputs
 | Output         | Description                                                                                                                                                           |

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
   timezone:
     description: 'IANA time zone name (e.g. America/Denver) to display dates in.  If timezone is not provided, dates will be shown in UTC.'
     required: false
+  comment-identifier:
+    description: 'Used when there is multiple test projects that run separtely but part of the same CI run.'
+    required: false
 
 outputs:
   test-outcome:

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
     description: 'IANA time zone name (e.g. America/Denver) to display dates in.  If timezone is not provided, dates will be shown in UTC.'
     required: false
   comment-identifier:
-    description: 'Used when there is multiple test projects that run separtely but part of the same CI run.'
+    description: 'Used when there are multiple test projects that run separately but are part of the same CI run.'
     required: false
 
 outputs:

--- a/src/github.js
+++ b/src/github.js
@@ -37,7 +37,7 @@ async function createStatusCheck(repoToken, reportData, markupData, conclusion) 
   }
 }
 
-async function lookForExistingComment(octokit) {
+async function lookForExistingComment(octokit, commentIdentifier) {
   let hasMoreComments = true;
   let page = 1;
   const maxResultsPerPage = 30;
@@ -59,7 +59,7 @@ async function lookForExistingComment(octokit) {
           page += 1;
         }
 
-        const existingComment = commentsResponse.data.find(c => c.body.startsWith(markupPrefix));
+        const existingComment = commentsResponse.data.find(c => c.body.startsWith(markupPrefix + commentIdentifier));
         if (existingComment) {
           core.info(`An existing dotnet test results comment (${existingComment.id}) was found and will be udpated.`);
           return existingComment.id;
@@ -77,7 +77,7 @@ async function lookForExistingComment(octokit) {
   return null;
 }
 
-async function createPrComment(repoToken, markupData, updateCommentIfOneExists) {
+async function createPrComment(repoToken, markupData, updateCommentIfOneExists, commentIdentifier) {
   try {
     if (github.context.eventName != 'pull_request') {
       core.info('This event was not triggered by a pull_request.  No comment will be created or updated.');
@@ -89,7 +89,7 @@ async function createPrComment(repoToken, markupData, updateCommentIfOneExists) 
     let existingCommentId = null;
     if (updateCommentIfOneExists) {
       core.info('Checking for existing comment on PR....');
-      existingCommentId = await lookForExistingComment(octokit);
+      existingCommentId = await lookForExistingComment(octokit, commentIdentifier);
     }
 
     let response;

--- a/src/github.js
+++ b/src/github.js
@@ -1,6 +1,5 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
-const markupPrefix = 'im-open/process-dotnet-test-results';
 
 async function createStatusCheck(repoToken, reportData, markupData, conclusion) {
   try {
@@ -37,7 +36,7 @@ async function createStatusCheck(repoToken, reportData, markupData, conclusion) 
   }
 }
 
-async function lookForExistingComment(octokit, commentIdentifier) {
+async function lookForExistingComment(octokit, markupPrefix) {
   let hasMoreComments = true;
   let page = 1;
   const maxResultsPerPage = 30;
@@ -58,8 +57,8 @@ async function lookForExistingComment(octokit, commentIdentifier) {
         } else {
           page += 1;
         }
-        
-        const existingComment = commentsResponse.data.find(c => c.body.startsWith(`<!-- ${markupPrefix}${commentIdentifier} -->`));
+
+        const existingComment = commentsResponse.data.find(c => c.body.startsWith(markupPrefix));
         if (existingComment) {
           core.info(`An existing dotnet test results comment (${existingComment.id}) was found and will be udpated.`);
           return existingComment.id;
@@ -83,13 +82,13 @@ async function createPrComment(repoToken, markupData, updateCommentIfOneExists, 
       core.info('This event was not triggered by a pull_request.  No comment will be created or updated.');
       return;
     }
-
+    const markupPrefix = `<!-- im-open/process-dotnet-test-results ${commentIdentifier} -->`;
     const octokit = github.getOctokit(repoToken);
 
     let existingCommentId = null;
     if (updateCommentIfOneExists) {
       core.info('Checking for existing comment on PR....');
-      existingCommentId = await lookForExistingComment(octokit, commentIdentifier);
+      existingCommentId = await lookForExistingComment(octokit, markupPrefix);
     }
 
     let response;

--- a/src/github.js
+++ b/src/github.js
@@ -1,6 +1,6 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
-const markupPrefix = '<!-- im-open/process-dotnet-test-results -->';
+const markupPrefix = 'im-open/process-dotnet-test-results';
 
 async function createStatusCheck(repoToken, reportData, markupData, conclusion) {
   try {
@@ -58,8 +58,8 @@ async function lookForExistingComment(octokit, commentIdentifier) {
         } else {
           page += 1;
         }
-
-        const existingComment = commentsResponse.data.find(c => c.body.startsWith(markupPrefix + commentIdentifier));
+        
+        const existingComment = commentsResponse.data.find(c => c.body.startsWith(`<!-- ${markupPrefix}${commentIdentifier} -->`));
         if (existingComment) {
           core.info(`An existing dotnet test results comment (${existingComment.id}) was found and will be udpated.`);
           return existingComment.id;

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,7 @@ const ignoreTestFailures = core.getInput('ignore-test-failures') == 'true';
 const shouldCreateStatusCheck = core.getInput('create-status-check') == 'true';
 const shouldCreatePRComment = core.getInput('create-pr-comment') == 'true';
 const updateCommentIfOneExists = core.getInput('update-comment-if-one-exists') == 'true';
-const commentIdentifier = core.getInput('comment-identifier') == '';
+const commentIdentifier = core.getInput('comment-identifier') || '';
 
 async function run() {
   try {

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ const ignoreTestFailures = core.getInput('ignore-test-failures') == 'true';
 const shouldCreateStatusCheck = core.getInput('create-status-check') == 'true';
 const shouldCreatePRComment = core.getInput('create-pr-comment') == 'true';
 const updateCommentIfOneExists = core.getInput('update-comment-if-one-exists') == 'true';
+const commentIdentifier = core.getInput('comment-identifier') == '';
 
 async function run() {
   try {
@@ -37,7 +38,7 @@ async function run() {
     }
 
     if (markupForComment.length > 0) {
-      await createPrComment(token, markupForComment.join('\n'), updateCommentIfOneExists);
+      await createPrComment(token, markupForComment.join('\n'), updateCommentIfOneExists, commentIdentifier);
     }
 
     core.setOutput('test-outcome', failingTestsFound ? 'Failed' : 'Passed');


### PR DESCRIPTION
# Summary of PR changes

In Account Management we have a mono repo and run build and tests based of changes to different projects and not the whole solution. This will update to the last run test results in the comment and over ride any results that were update prior but within the same CI run. We would like to add an identifier to the markdown prefix so we can update comments that are unique to the test project.

Have not been able to test since my fork is not part of the im org and it was not trusted to run.

## PR Requirements
- [x] For JavaScript actions, the action has been recompiled.  
  - See the *Recompiling* section of the repository's README.md for more details.
  - This does not apply to Composite Run Steps actions unless a package.json is present and contains a build script.
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
