### PR TITLE
Run on Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,5 +42,5 @@ outputs:
     description: 'List of trx files that were processed'
 
 runs:
-  using: 'node12'
+  using: 'node16
   main: 'dist/index.js'


### PR DESCRIPTION
Based on this announcement, all actions should be migrated to node 16 https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

# Summary of PR changes
- Update action.yml to use node16