### PR TITLE
Bump node version to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,6 @@ outputs:
     description: 'File path of the test outcome in markdown format.  This is the same output that is posted in the PR comment'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
   post: 'dist/cleanup.js'


### PR DESCRIPTION
Fixes deprecation warning in github

# Summary of PR changes
Bump node version from 16 to 20 in github action using statement in order to fix the github deprecation warning related to node 16.

## PR Requirements
- [ ] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [ ] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
