### PR TITLE
DEVO-1054 - bump to Node 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ jobs:
       - name: Process trx reports with default
         if: always()
         # You may also reference just the major or major.minor version
-        uses: im-open/process-dotnet-test-results@v3.0.2
+        uses: im-open/process-dotnet-test-results@v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -145,7 +145,7 @@ jobs:
       - name: Process trx reports
         id: process-trx
         # You may also reference just the major or major.minor version
-        uses: im-open/process-dotnet-test-results@v3.0.2
+        uses: im-open/process-dotnet-test-results@v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           base-directory: './test-results'
@@ -201,7 +201,7 @@ jobs:
         if: always()
         id: process-test
         # You may also reference just the major or major.minor version
-        uses: im-open/process-dotnet-test-results@v3.0.2
+        uses: im-open/process-dotnet-test-results@v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           create-status-check: false

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ jobs:
       - name: Process trx reports with default
         if: always()
         # You may also reference just the major or major.minor version
-        uses: im-open/process-dotnet-test-results@v3.0.1
+        uses: im-open/process-dotnet-test-results@v3.0.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -145,7 +145,7 @@ jobs:
       - name: Process trx reports
         id: process-trx
         # You may also reference just the major or major.minor version
-        uses: im-open/process-dotnet-test-results@v3.0.1
+        uses: im-open/process-dotnet-test-results@v3.0.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           base-directory: './test-results'
@@ -201,7 +201,7 @@ jobs:
         if: always()
         id: process-test
         # You may also reference just the major or major.minor version
-        uses: im-open/process-dotnet-test-results@v3.0.1
+        uses: im-open/process-dotnet-test-results@v3.0.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           create-status-check: false

--- a/action.yml
+++ b/action.yml
@@ -62,5 +62,5 @@ outputs:
     description: 'The ID of the PR comment that was created.  This is only set if `create-pr-comment` is `true` and a PR was created successfully.'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
# Summary of PR changes

https://im-jira.internal.towerswatson.com/browse/DEVO-1054

Updated the GitHub Action to use Node 24 runtime instead of Node 20.

## Changes Made
- **`action.yml`**: Updated `runs.using` from `node20` to `node24` to use the latest Node.js runtime version supported by GitHub Actions.

## Reasoning
Node 20 is approaching end-of-life, and Node 24 provides better performance, security updates, and long-term support. This change ensures the action remains compatible with GitHub Actions' supported runtime environments.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
  - **Recommendation**: Use `+semver: major` or `+semver: minor` in your commit message, as changing the Node runtime version could be considered a breaking change for environments that haven't migrated to Node 24 yet.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version. For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
